### PR TITLE
Avoid unnecessary use of eval (insecure)

### DIFF
--- a/prepcomp/gnallcmp.py
+++ b/prepcomp/gnallcmp.py
@@ -52,7 +52,7 @@ with open("comps1.txt") as f:
             strCompReadable = ""
             for comp in comps:
                 try:
-                    numUni = eval("0x" + comp)
+                    numUni = int(comp, 16)
                     if numUni in range(0xA, 0x10):
                         strCompReadable += comp
                     else:


### PR DESCRIPTION
The appropriate way to convert a hexadecimal string to integer is by using the built-in functionality of `int`. The `eval` function is insecure; if the input could possibly come from outside the program, no matter how indirectly, this creates a risk of an arbitrary code execution exploit. It's also much less efficient.